### PR TITLE
driver prompt updated for inserting responses in English only

### DIFF
--- a/app/src/prompts/driver_screening.py
+++ b/app/src/prompts/driver_screening.py
@@ -59,11 +59,12 @@ Screening Process:
    - Ask the candidate to select a specific date and time from the options provided
    - If they mention only a day of the week without a date, ask them to specify which date they prefer
    - When they select a time slot, confirm their selection with a message like:
-     - English: "Your interview has been successfully scheduled for [selected date and time slot]. We look forward to seeing you at your interview. If you have any questions in the meantime, feel free to reach out. Thank you again for your interest in Lokiteck Logistics."
-     - Spanish: "Su entrevista ha sido programada con éxito para [selected date and time slot]. Esperamos verle en su entrevista. Si tiene alguna pregunta mientras tanto, no dude en contactarnos. Gracias nuevamente por su interés en Lokiteck Logistics."
-   - ONLY AFTER confirming the time slot, update their status to PASSED using the update_applicant_status tool (see STATUS UPDATE section below)
-   - DO NOT update the status until AFTER the candidate has selected a time slot and you have confirmed it
-   - After updating the status, you may inform the applicant: "Your status has been successfully updated to PASSED. We look forward to seeing you on [selected date and time]."
+     - English: "We have successfully scheduled your interview for [selected date and time slot]. We look forward to meeting you then. Please arrive 15 minutes prior to the scheduled time and bring any required documents. If you have any questions or concerns, please do not hesitate to reach out to us."
+     - Spanish: "Hemos programado con éxito su entrevista para [selected date and time slot]. Esperamos verte entonces. Por favor, llega 15 minutos antes de la hora programada y trae cualquier documento requerido. Si tienes alguna pregunta o inquietud, no dudes en hacérselo saber."
+   - CRITICAL: The VERY MOMENT a candidate selects a time slot and before sending the confirmation message, call the update_applicant_status tool to update their status to PASSED
+   - CRITICAL: Even if the conversation is in Spanish, you MUST TRANSLATE ALL responses to ENGLISH before adding them to the update_applicant_status tool call
+   - DO NOT inform the applicant about the status update
+   - Always update responses in ENGLISH only
 
 8. STATUS UPDATE
    - Update the applicant status using the update_applicant_status tool with the following JSON format:
@@ -74,19 +75,20 @@ Screening Process:
   "current_status": "[Current status from the applicant_details, default to INPROGRESS]",
   "new_status": "[PASSED or FAILED based on the screening result]",
   "responses": {{
-    "[Question 1 text]": "[Answer 1 text]",
-    "[Question 2 text]": "[Answer 2 text]",
-    "feedback": "[Brief evaluation summary]",
-    "selected_time_slot": "[Full date and time slot selected by the candidate, if applicable]"
+    "[Question 1 text in ENGLISH]": "[Answer 1 text in ENGLISH]",
+    "[Question 2 text in ENGLISH]": "[Answer 2 text in ENGLISH]",
+    ... include ALL questions and answers collected during screening (ALL TRANSLATED TO ENGLISH) ...,
+    "feedback": "[Brief evaluation summary in ENGLISH]",
+    "selected_time_slot": "[Full date and time slot selected by the candidate, in ENGLISH]"
   }}
 }}
 ```
 
 IMPORTANT REMINDER ABOUT STATUS UPDATES:
-- For PASSED candidates: You MUST call the update_applicant_status tool ONLY AFTER the candidate selects a time slot and you confirm it. DO NOT update the status before scheduling is complete.
+- For PASSED candidates: You MUST include ALL questions and answers in the responses object when calling update_applicant_status, not just the selected_time_slot.
 - The tool call should look like this:
 ```
-update_applicant_status({{"dsp_code": "LMDL", "applicant_id": 60, "current_status": "INPROGRESS", "new_status": "PASSED", "responses": {{"selected_time_slot": "Monday, April 21, 2025 9-5 PM"}}}})
+update_applicant_status({{"dsp_code": "LMDL", "applicant_id": 60, "current_status": "INPROGRESS", "new_status": "PASSED", "responses": {{"Do you have a valid driver's license?": "Yes, I have a valid Class C license for 5 years", "Are you comfortable with overnight routes?": "Yes, I am comfortable with overnight routes", "feedback": "Candidate meets all requirements", "selected_time_slot": "Monday, April 21, 2025 9-5 PM"}}}})
 ```
 - For FAILED candidates: Update their status FIRST, then provide the rejection message with specific feedback. DO NOT mention that you are updating their status or wait for acknowledgment.
 - If the applicant details are not found, provide the company's contact information.
@@ -96,10 +98,9 @@ Key Guidelines:
 - Only ask company-specific questions provided
 - Confirm responses before evaluation
 - Support both English and Spanish based on the applicant's preference
-- If the applicant chooses Spanish, conduct the entire conversation in Spanish
+- If the applicant chooses Spanish, conduct the entire conversation in Spanish but TRANSLATE ALL RESPONSES TO ENGLISH before updating the status
 - Inform the applicant about their screening result in the formal closing message
-- For passed candidates, update their status IMMEDIATELY after confirming the interview time
-- Always update responses in ENGLISH
+- CRITICAL: ALL database updates must be in ENGLISH regardless of conversation language
 
 Use a consistent driver_id format (e.g., "DRIVER-" followed by the first 5 letters of their name and a timestamp) to ensure uniqueness.
 """
@@ -167,11 +168,12 @@ Screening Process:
    - Ask the candidate to select a specific date and time from the options provided
    - If they mention only a day of the week without a date, ask them to specify which date they prefer
    - When they select a time slot, confirm their selection with a message like:
-     - English: "Your interview has been successfully scheduled for [selected date and time slot]. We look forward to seeing you at your interview. If you have any questions in the meantime, feel free to reach out. Thank you again for your interest in Lokiteck Logistics."
-     - Spanish: "Su entrevista ha sido programada con éxito para [selected date and time slot]. Esperamos verle en su entrevista. Si tiene alguna pregunta mientras tanto, no dude en contactarnos. Gracias nuevamente por su interés en Lokiteck Logistics."
-   - ONLY AFTER confirming the time slot, update their status to PASSED using the update_applicant_status tool (see STATUS UPDATE section below)
-   - DO NOT update the status until AFTER the candidate has selected a time slot and you have confirmed it
-   - After updating the status, you may inform the applicant: "Your status has been successfully updated to PASSED. We look forward to seeing you on [selected date and time]."
+     - English: "We have successfully scheduled your interview for [selected date and time slot]. We look forward to meeting you then. Please arrive 15 minutes prior to the scheduled time and bring any required documents. If you have any questions or concerns, please do not hesitate to reach out to us."
+     - Spanish: "Hemos programado con éxito su entrevista para [selected date and time slot]. Esperamos verte entonces. Por favor, llega 15 minutos antes de la hora programada y trae cualquier documento requerido. Si tienes alguna pregunta o inquietud, no dudes en hacérselo saber."
+   - CRITICAL: The VERY MOMENT a candidate selects a time slot and before sending the confirmation message, call the update_applicant_status tool to update their status to PASSED
+   - CRITICAL: Even if the conversation is in Spanish, you MUST TRANSLATE ALL responses to ENGLISH before adding them to the update_applicant_status tool call
+   - DO NOT inform the applicant about the status update
+   - Always update responses in ENGLISH only
 
 8. STATUS UPDATE
    - Update the applicant status using the update_applicant_status tool with the following JSON format:
@@ -182,19 +184,20 @@ Screening Process:
   "current_status": "[Current status from the applicant_details, default to INPROGRESS]",
   "new_status": "[PASSED or FAILED based on the screening result]",
   "responses": {{
-    "[Question 1 text]": "[Answer 1 text]",
-    "[Question 2 text]": "[Answer 2 text]",
-    "feedback": "[Brief evaluation summary]",
-    "selected_time_slot": "[Full date and time slot selected by the candidate, if applicable]"
+    "[Question 1 text in ENGLISH]": "[Answer 1 text in ENGLISH]",
+    "[Question 2 text in ENGLISH]": "[Answer 2 text in ENGLISH]",
+    ... include ALL questions and answers collected during screening (ALL TRANSLATED TO ENGLISH) ...,
+    "feedback": "[Brief evaluation summary in ENGLISH]",
+    "selected_time_slot": "[Full date and time slot selected by the candidate, in ENGLISH]"
   }}
 }}
 ```
 
 IMPORTANT REMINDER ABOUT STATUS UPDATES:
-- For PASSED candidates: You MUST call the update_applicant_status tool ONLY AFTER the candidate selects a time slot and you confirm it. DO NOT update the status before scheduling is complete.
+- For PASSED candidates: You MUST include ALL questions and answers in the responses object when calling update_applicant_status, not just the selected_time_slot.
 - The tool call should look like this:
 ```
-update_applicant_status({{"dsp_code": "LMDL", "applicant_id": 60, "current_status": "INPROGRESS", "new_status": "PASSED", "responses": {{"selected_time_slot": "Monday, April 21, 2025 9-5 PM"}}}})
+update_applicant_status({{"dsp_code": "LMDL", "applicant_id": 60, "current_status": "INPROGRESS", "new_status": "PASSED", "responses": {{"Do you have a valid driver's license?": "Yes, I have a valid Class C license for 5 years", "Are you comfortable with overnight routes?": "Yes, I am comfortable with overnight routes", "feedback": "Candidate meets all requirements", "selected_time_slot": "Monday, April 21, 2025 9-5 PM"}}}})
 ```
 - For FAILED candidates: Update their status FIRST, then provide the rejection message with specific feedback. DO NOT mention that you are updating their status or wait for acknowledgment.
 - If the applicant details are not found, provide the company's contact information.
@@ -205,10 +208,9 @@ Key Guidelines:
 - Only ask company-specific questions provided
 - Confirm responses before evaluation
 - Support both English and Spanish based on the applicant's preference
-- If the applicant chooses Spanish, conduct the entire conversation in Spanish
+- If the applicant chooses Spanish, conduct the entire conversation in Spanish but TRANSLATE ALL RESPONSES TO ENGLISH before updating the status
 - Inform the applicant about their screening result in the formal closing message
-- For passed candidates, update their status IMMEDIATELY after confirming the interview time
-- Always update responses in ENGLISH
+- CRITICAL: ALL database updates must be in ENGLISH regardless of conversation language
 
 Use a consistent driver_id format (e.g., "DRIVER-" followed by the first 5 letters of their name and a timestamp) to ensure uniqueness.
 """


### PR DESCRIPTION
Immediate Status Update:
Changed the wording from "IMMEDIATELY after" to "CRITICAL: The VERY MOMENT"
Specified that the update should happen "before sending the confirmation message"
This ensures the status is updated immediately when a time slot is selected
English-Only Responses:
Added "CRITICAL" emphasis throughout the prompt
Explicitly stated "TRANSLATE ALL RESPONSES TO ENGLISH" multiple times
Modified the JSON example to show "[Question text in ENGLISH]" and "[Answer text in ENGLISH]"
Added "(ALL TRANSLATED TO ENGLISH)" to the instruction about including all questions
Updated Key Guidelines:
Changed "If the applicant chooses Spanish, conduct the entire conversation in Spanish" to include "but TRANSLATE ALL RESPONSES TO ENGLISH before updating the status"
Replaced "Always update responses in ENGLISH only" with "CRITICAL: ALL database updates must be in ENGLISH regardless of conversation language"